### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to OpenWhisk
+
+We welcome contributions, but request you follow these guidelines.
+
+ - [Raising issues](#raising-issues)
+ - [Contributor License Agreement](#contributor-license-agreement)
+ - [Coding Standards](#coding-standards)
+ 
+## Raising issues
+
+Please raise any bug reports on the issue tracker. Be sure to
+search the list to see if your issue has already been raised.
+
+A good bug report is one that make it easy for us to understand what you were
+trying to do and what went wrong. Provide as much context as possible so we can try to recreate the issue.
+
+
+### Contributor License Agreement
+
+In order for us to accept pull-requests, the contributor must first complete
+a Contributor License Agreement (CLA). This clarifies the intellectual
+property license granted with any contribution. It is for your protection as a
+Contributor as well as the protection of IBM and its customers; it does not
+change your rights to use your own Contributions for any other purpose.
+
+You can download the CLAs here:
+
+- [individual](https://github.com/openwhisk/openwhisk/blob/master/CLA-INDIVIDUAL.md)
+- [corporate](https://github.com/openwhisk/openwhisk/blob/master/CLA-CORPORATE.md)
+
+
+### Coding standards
+
+Please ensure you follow the coding standards used throughout the existing
+code base. Some basic rules include:
+
+ - all files must have the Apache license in the header.
+ - all PRs must have passing builds for all operating systems.


### PR DESCRIPTION
Initial check-in.  Note, this may need to change depending on eventual CLI tutorial license.