### PR TITLE
Move the install scritps and util from OpenWhisk to OpenWhisk-catalog

### DIFF
--- a/packages-test/README.md
+++ b/packages-test/README.md
@@ -1,0 +1,19 @@
+# openwhisk-catalog test
+
+In order to make sure all the packages are moved in a correct way, we created all the test
+scripts in this directory. Each script has one corresponding test script. When all the packages
+have successfully moved into openwhisk-catalog, this test folder can be removed if necessary.
+
+Initially all the test scripts will fail, since there are packages' relocations on their way.
+After this patch, each pull request should run the designated test with no error to make sure
+the package is moved in a correct way. For example, if you are working on the movement of utils,
+the UtilTest.sh should run with no error; if you are working on the movement of github, you need
+to make sure installGitTest.sh is running fine.
+
+1. Before running each script, please make sure that the ${OPENWHISK_HOME} directory is in the
+same directory as openwhisk-catalog is. The script "installCatalogTest.sh" is supposed to
+test all the scripts, while each of the rest scripts can run individually as well. 
+2. In addition, please make sure that there is a valid file whisk.properties under openwhisk home and a valid file auth.whisk.system under ${OPENWHISK_HOME}/config/keys/ with authorization key. You need to specify a valid key "edge.host" in whisk.properties. The edge host is meant to be the machine, where the service is installed. 
+3. Don't forget to give all the permissions to all the scripts and their test scripts by
+"(sudo) chmod 777 <script_file>".
+

--- a/packages-test/installCatalogTest.sh
+++ b/packages-test/installCatalogTest.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Test the script of installCatalog.sh.
+#
+#
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+echo "This script is about to test another script installCatalog.sh."
+sh ./../packages/installCatalog.sh $SCRIPTDIR/../../openwhisk/config/keys/auth.whisk.system
+echo "This script has just run another script installCatalog.sh."

--- a/packages-test/installGitTest.sh
+++ b/packages-test/installGitTest.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Test the script of installGit.sh.
+#
+#
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+source "$SCRIPTDIR/../packages/util.sh"
+
+WHISK_SYSTEM_AUTH_FILE=$SCRIPTDIR/../../openwhisk/config/keys/auth.whisk.system
+: ${WHISK_SYSTEM_AUTH_FILE:?"WHISK_SYSTEM_AUTH_FILE must be set and non-empty"}
+
+export WHISK_SYSTEM_AUTH=`cat $WHISK_SYSTEM_AUTH_FILE`
+
+echo "This script is about to test another script installGit.sh."
+runPackageInstallScript "$SCRIPTDIR/../packages/" installGit.sh
+echo "This script has just run another script installGit.sh."

--- a/packages-test/installSlackTest.sh
+++ b/packages-test/installSlackTest.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Test the script of installSlack.sh.
+#
+#
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+source "$SCRIPTDIR/../packages/util.sh"
+
+WHISK_SYSTEM_AUTH_FILE=$SCRIPTDIR/../../openwhisk/config/keys/auth.whisk.system
+: ${WHISK_SYSTEM_AUTH_FILE:?"WHISK_SYSTEM_AUTH_FILE must be set and non-empty"}
+
+export WHISK_SYSTEM_AUTH=`cat $WHISK_SYSTEM_AUTH_FILE`
+
+echo "This script is about to test another script installSlack.sh."
+sh ./../packages/installSlack.sh
+echo "This script has just run another script installSlack.sh."

--- a/packages-test/installSystemTest.sh
+++ b/packages-test/installSystemTest.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Test the script of installSystem.sh.
+#
+#
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+source "$SCRIPTDIR/../packages/util.sh"
+
+WHISK_SYSTEM_AUTH_FILE=$SCRIPTDIR/../../openwhisk/config/keys/auth.whisk.system
+: ${WHISK_SYSTEM_AUTH_FILE:?"WHISK_SYSTEM_AUTH_FILE must be set and non-empty"}
+
+export WHISK_SYSTEM_AUTH=`cat $WHISK_SYSTEM_AUTH_FILE`
+
+echo "This script is about to test another script installSystem.sh."
+sh ./../packages/installSystem.sh
+echo "This script has just run another script installSystem.sh."

--- a/packages-test/installWatsonTest.sh
+++ b/packages-test/installWatsonTest.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Test the script of installWatson.sh.
+#
+#
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+source "$SCRIPTDIR/../packages/util.sh"
+
+WHISK_SYSTEM_AUTH_FILE=$SCRIPTDIR/../../openwhisk/config/keys/auth.whisk.system
+: ${WHISK_SYSTEM_AUTH_FILE:?"WHISK_SYSTEM_AUTH_FILE must be set and non-empty"}
+
+export WHISK_SYSTEM_AUTH=`cat $WHISK_SYSTEM_AUTH_FILE`
+
+echo "This script is about to test another script installWatson.sh."
+sh ./../packages/installWatson.sh
+echo "This script has just run another script installWatson.sh."

--- a/packages-test/installWeatherTest.sh
+++ b/packages-test/installWeatherTest.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Test the script of installWeather.sh.
+#
+#
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+source "$SCRIPTDIR/../packages/util.sh"
+
+WHISK_SYSTEM_AUTH_FILE=$SCRIPTDIR/../../openwhisk/config/keys/auth.whisk.system
+: ${WHISK_SYSTEM_AUTH_FILE:?"WHISK_SYSTEM_AUTH_FILE must be set and non-empty"}
+
+export WHISK_SYSTEM_AUTH=`cat $WHISK_SYSTEM_AUTH_FILE`
+
+echo "This script is about to test another script installWeather.sh."
+sh ./../packages/installWeather.sh
+echo "This script has just run another script installWeather.sh."

--- a/packages-test/utilTest.sh
+++ b/packages-test/utilTest.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Test the script of util.sh.
+#
+#
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+echo "This script is about to test another script util.sh."
+sh ./../packages/util.sh
+echo "This script has just run another script util.sh."

--- a/packages/installCatalog.sh
+++ b/packages/installCatalog.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# use the command line interface to install standard actions deployed
+# automatically
+#
+WHISK_SYSTEM_AUTH_FILE=$1
+: ${WHISK_SYSTEM_AUTH_FILE:?"WHISK_SYSTEM_AUTH_FILE must be set and non-empty"}
+
+export WHISK_SYSTEM_AUTH=`cat $WHISK_SYSTEM_AUTH_FILE`
+
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+source "$SCRIPTDIR/util.sh"
+
+echo Installing open catalog
+
+runPackageInstallScript "$SCRIPTDIR" installSystem.sh
+runPackageInstallScript "$SCRIPTDIR" installGit.sh
+runPackageInstallScript "$SCRIPTDIR" installSlack.sh
+runPackageInstallScript "$SCRIPTDIR" installWatson.sh
+runPackageInstallScript "$SCRIPTDIR" installWeather.sh
+
+waitForAll
+
+echo open catalog ERRORS = $ERRORS
+exit $ERRORS

--- a/packages/installGit.sh
+++ b/packages/installGit.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# use the command line interface to install Git package.
+#
+: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
+AUTH_KEY=$WHISK_SYSTEM_AUTH
+
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+CATALOG_HOME=$SCRIPTDIR
+source "$CATALOG_HOME/util.sh"
+
+echo Installing Git package.
+
+createPackage github \
+    -a description "Package which contains actions and feeds to interact with Github"
+
+waitForAll
+
+install "$CATALOG_HOME/github/webhook.js" \
+    github/webhook \
+    -a feed true \
+    -a description 'Creates a webhook on github to be notified on selected changes' \
+    -a parameters '[ {"name":"username", "required":true, "bindTime":true}, {"name":"repository", "required":true, "bindTime":true}, {"name":"accessToken", "required":true, "bindTime":true},{"name":"events", "required":true} ]' \
+    -a sampleInput '{"username":"whisk", "repository":"WhiskRepository", "accessToken":"123ABCXYZ", "events": "push,commit,delete"}'
+
+waitForAll
+
+echo Git package ERRORS = $ERRORS
+exit $ERRORS

--- a/packages/installSlack.sh
+++ b/packages/installSlack.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# use the command line interface to install Slack package.
+#
+: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
+AUTH_KEY=$WHISK_SYSTEM_AUTH
+
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+CATALOG_HOME=$SCRIPTDIR
+source "$CATALOG_HOME/util.sh"
+
+echo Installing Slack package.
+
+createPackage slack \
+    -a description "Package which contains actions to interact with the Slack messaging service"
+
+waitForAll
+
+install "$CATALOG_HOME/slack/post.js" \
+    slack/post \
+    -a description 'Posts a message to Slack' \
+    -a parameters '[ {"name":"username", "required":true, "bindTime":true}, {"name":"text", "required":true}, {"name":"url", "required":true, "bindTime":true},{"name":"channel", "required":true, "bindTime":true} ]' \
+    -a sampleInput '{"username":"whisk", "text":"Hello whisk!", "channel":"myChannel", "url": "https://hooks.slack.com/services/XYZ/ABCDEFG/12345678"}'
+
+waitForAll
+
+echo Slack package ERRORS = $ERRORS
+exit $ERRORS

--- a/packages/installSystem.sh
+++ b/packages/installSystem.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# use the command line interface to install standard actions deployed
+# automatically.
+#
+: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
+AUTH_KEY=$WHISK_SYSTEM_AUTH
+
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+CATALOG_HOME=$SCRIPTDIR
+source "$CATALOG_HOME/util.sh"
+
+echo Installing whisk.system entities.
+
+createPackage system -a description "Low-level OpenWhisk utilities"
+createPackage util -a description "Building blocks that format and assemble data"
+createPackage samples -a description "A suite of simple actions to help you get started with OpenWhisk"
+
+waitForAll
+
+install "$CATALOG_HOME/utils/pipe.js" \
+     system/pipe \
+     -a system true
+
+install "$CATALOG_HOME/utils/cat.js" \
+     util/cat \
+     -a description 'Concatenates input into a string' \
+     -a parameters '[ { "name": "lines", "required": true, "type": "array", "description": "An array of strings or numbers" } ]' \
+     -a sampleInput '{ "lines": [4, 2, 3] }' \
+     -a sampleOutput '{ "lines": [4, 2, 3] }'
+
+install "$CATALOG_HOME/utils/split.js" \
+     util/split \
+     -a description 'Split a string into an array' \
+     -a parameters '[{"name": "payload", "required":true, "description":"A string"}], { "name": "separator", "required": false, "description": "The character, or the regular expression, to use for splitting the string }]' \
+     -a sampleInput '{ "payload": "one,two,three" "separator": "," }' \
+     -a sampleOutput '{ "lines": [one, two, three], "payload": "one,two,three"}'
+
+install "$CATALOG_HOME/utils/sort.js" \
+     util/sort \
+     -a description 'Sorts an array' \
+     -a parameters '[ { "name": "lines", "required": true, "type": "array", "description": "An array of strings" } ]' \
+     -a sampleInput '{ "lines": [4, 2, 3] }' \
+     -a sampleOutput '{ "lines": [2, 3, 4], "length": 3 }'
+
+install "$CATALOG_HOME/utils/head.js" \
+     util/head \
+     -a description 'Extract prefix of an array' \
+     -a parameters '[ { "name": "lines", "required": true, "type": "array", "description": "An array of strings" }, { "name": "num", "required": false, "type": "integer", "description": "The length of the prefix" }]' \
+     -a sampleInput '{ "lines": [4, 2, 3], "num": 2 }' \
+     -a sampleOutput '{ "lines": [4, 2], "num": 2 }'
+
+install "$CATALOG_HOME/utils/date.js" \
+     util/date \
+     -a description 'Current date and time' \
+     -a sampleOutput '{ "date": "2016-03-22T00:59:55.961Z" }'
+
+install "$CATALOG_HOME/samples/hello.js" \
+     samples/helloWorld \
+     -a description 'Demonstrates logging facilities' -a parameters '[{"name": "payload", "required":false, "description":"The string to be included in the log record"}]' \
+     -a sampleInput '{ "payload": "Cat" }' \
+     -a sampleOutput '{ }' \
+     -a sampleLogOutput '2016-03-22T01:02:26.387624916Z stdout: hello Cat!'
+
+install "$CATALOG_HOME/samples/greeting.js" \
+     samples/greeting \
+     -a description 'Returns a friendly greeting' \
+     -a parameters '[{"name": "name", "required":false}, {"name": "place", "required":false, "description":"The string to be included in the return value"}]' \
+     -a sampleInput '{ "payload": "Cat", "place": "Narrowsburg" }' \
+     -a sampleOutput '{ "payload": "Hello, Cat from Narrowsburg!" }' \
+     -a sampleLogOutput "2016-03-22T01:07:08.384982272Z stdout: params: { place: 'Narrowsburg', payload: 'Cat' }"
+
+install "$CATALOG_HOME/samples/wc.js" \
+     samples/wordCount \
+     -a description 'Count words in a string' -a parameters '[{"name": "payload", "required":true, "description":"A string"}]' \
+     -a sampleInput '{ "payload": "Five fuzzy felines"}' \
+     -a sampleOutput '{ "count": 3 }' \
+     -a sampleLogOutput "2016-03-22T01:10:07.361649586Z stdout: The message 'Five fuzzy felines' has 3 words"
+
+install "$CATALOG_HOME/samples/echo.js" \
+    samples/echo \
+    -a description 'Returns the input' -a parameters '[{"name": "payload", "required":false, "description": "Any JSON entity"}]' \
+    -a sampleInput '{ "payload": "Five fuzzy felines"}' \
+    -a sampleOutput '{ "payload": "Five fuzzy felines"}'
+
+waitForAll
+
+echo whisk.system entities ERRORS = $ERRORS
+exit $ERRORS

--- a/packages/installWatson.sh
+++ b/packages/installWatson.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+#
+# use the command line interface to install Watson package.
+#
+: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
+AUTH_KEY=$WHISK_SYSTEM_AUTH
+
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+CATALOG_HOME=$SCRIPTDIR
+source "$CATALOG_HOME/util.sh"
+
+echo Installing Watson package.
+
+createPackage watson \
+    -a description "Actions for the Watson analytics APIs" \
+    -a parameters '[ {"name":"username", "required":false}, {"name":"password", "required":false, "type":"password"} ]'
+
+waitForAll
+
+install "$CATALOG_HOME/watson/speechToText.js" \
+    watson/speechToText \
+    -a description 'Convert speech to text' \
+    -a parameters '[
+  {
+    "name": "content_type",
+    "required": true,
+    "description": "The MIME type of the audio"
+  },
+  {
+    "name": "model",
+    "required": false,
+    "description": "The identifier of the model to be used for the recognition request"
+  },
+  {
+    "name": "continuous",
+    "required": false,
+    "description": "Indicates whether multiple final results that represent consecutive phrases separated by long pauses are returned"
+  },
+  {
+    "name": "inactivity_timeout",
+    "required": false,
+    "description": "The time in seconds after which, if only silence (no speech) is detected in submitted audio, the connection is closed"
+  },
+  {
+    "name": "interim_results",
+    "required": false,
+    "description": "Indicates whether the service is to return interim results"
+  },
+  {
+    "name": "keywords",
+    "required": false,
+    "description": "A list of keywords to spot in the audio"
+  },
+  {
+    "name": "keywords_threshold",
+    "required": false,
+    "description": "A confidence value that is the lower bound for spotting a keyword"
+  },
+  {
+    "name": "max_alternatives",
+    "required": false,
+    "description": "The maximum number of alternative transcripts to be returned"
+  },
+  {
+    "name": "word_alternatives_threshold",
+    "required": false,
+    "description": "A confidence value that is the lower bound for identifying a hypothesis as a possible word alternative"
+  },
+  {
+    "name": "word_confidence",
+    "required": false,
+    "description": "Indicates whether a confidence measure in the range of 0 to 1 is to be returned for each word"
+  },
+  {
+    "name": "timestamps",
+    "required": false,
+    "description": "Indicates whether time alignment is returned for each word"
+  },
+  {
+    "name": "X-Watson-Learning-Opt-Out",
+    "required": false,
+    "description": "Indicates whether to opt out of data collection for the call"
+  },
+  {
+    "name": "watson-token",
+    "required": false,
+    "description": "Provides an authentication token for the service as an alternative to providing service credentials"
+  },
+  {
+    "name": "encoding",
+    "required": true,
+    "description": "The encoding of the speech binary data"
+  },
+  {
+    "name": "payload",
+    "required": true,
+    "description": "The encoding of the speech binary data"
+  },
+  {
+    "name": "username",
+    "required": true,
+    "bindTime": true,
+    "description": "The Watson service username"
+  },
+  {
+    "name": "password",
+    "required": true,
+    "type": "password",
+    "bindTime": true,
+    "description": "The Watson service password"
+  }
+]' \
+    -a sampleInput '{"payload":"<base64 encoding of a wav file>", "encoding":"base64", "content_type":"audio/wav", "username":"XXX", "password":"XXX"}' \
+    -a sampleOutput '{"data":"Hello."}'
+
+install "$CATALOG_HOME/watson/translate.js" \
+    watson/translate \
+    -a description 'Translate text' \
+    -a parameters '[ {"name":"translateFrom", "required":false}, {"name":"translateTo", "required":false}, {"name":"translateParam", "required":false}, {"name":"username", "required":true, "bindTime":true}, {"name":"password", "required":true, "type":"password", "bindTime":true} ]' \
+    -a sampleInput '{"translateFrom":"en", "translateTo":"fr", "payload":"Hello", "username":"XXX", "password":"XXX"}' \
+    -a sampleOutput '{"payload":"Bonjour"}'
+
+install "$CATALOG_HOME/watson/languageId.js" \
+    watson/languageId \
+    -a description 'Identify language' \
+    -a parameters '[ {"name":"username", "required":true, "bindTime":true}, {"name":"password", "required":true, "type":"password", "bindTime":true}, {"name":"payload", "required":true} ]' \
+    -a sampleInput '{"payload": "Bonjour", "username":"XXX", "password":"XXX"}' \
+    -a sampleOutput '{"language": "French", "confidence": 1}'
+
+install "$CATALOG_HOME/watson/textToSpeech.js" \
+    watson/textToSpeech \
+    -a description 'Synthesize text to spoken audio' \
+    -a parameters '[
+        {"name":"username", "required":true, "bindTime":true, "description":"The Watson service username"},
+        {"name":"password", "required":true, "type":"password", "bindTime":true, "description":"The Watson service password"},
+        {"name":"payload", "required":true, "description":"The text to be synthesized"},
+        {"name":"voice", "required":false, "description":"The voice to be used for synthesis"},
+        {"name":"accept", "required":false, "description":"The requested MIME type of the audio"},
+        {"name":"encoding", "required":false, "description":"The encoding of the speech binary data"}]' \
+    -a sampleInput '{"payload":"Hello, world.", "encoding":"base64", "accept":"audio/wav", "username":"XXX", "password":"XXX" }' \
+    -a sampleOutput '{"payload":"<base64 encoding of a .wav file>", "encoding":"base64", "content_type":"audio/wav"}'
+
+waitForAll
+
+echo Watson package ERRORS = $ERRORS
+exit $ERRORS

--- a/packages/installWeather.sh
+++ b/packages/installWeather.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# use the command line interface to install Weather.com package.
+#
+: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
+AUTH_KEY=$WHISK_SYSTEM_AUTH
+
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+CATALOG_HOME=$SCRIPTDIR
+source "$CATALOG_HOME/util.sh"
+
+echo Installing Weather package.
+
+createPackage weather \
+    -a description "Services from IBM Weather Insights" \
+    -a parameters '[ {"name":"apiKey", "required":false, "bindTime":true} ]'
+
+waitForAll
+
+install "$CATALOG_HOME/weather/forecast.js" \
+    weather/forecast \
+    -a description 'IBM Weather Insights 10-day forecast' \
+    -a parameters '[ {"name":"latitude", "required":true}, {"name":"longitude", "required":true},{"name":"language", "required":false},{"name":"units", "required":false}, {"name":"timePeriod", "required":false}, {"name":"apiKey", "required":true, "type":"password", "bindTime":true} ]' \
+    -a sampleInput '{"latitude":"34.063", "longitude":"-84.217", "apiKey":"XXX"}' \
+    -a sampleOutput '{"forecasts":[ {"dow":"Monday", "min_temp":30, "max_temp":38, "narrative":"Cloudy"} ]}'
+
+waitForAll
+
+echo Weather package ERRORS = $ERRORS
+exit $ERRORS

--- a/packages/util.sh
+++ b/packages/util.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# utility functions used when installing standard whisk assets during deployment
+#
+# Note use of --apihost, this is needed in case of a b/g swap since the router may not be
+# updated yet and there may be a breaking change in the API. All tests should go through edge.
+
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+OPENWHISK_HOME=${OPENWHISK_HOME:-$SCRIPTDIR/../../openwhisk}
+
+WHISKPROPS_FILE="$OPENWHISK_HOME/whisk.properties"
+if [ ! -f "$WHISKPROPS_FILE" ]; then
+    echo "whisk properties file not found $WHISKPROPS_FILE"
+    exit 1
+fi
+EDGE_HOST=`fgrep edge.host= "$WHISKPROPS_FILE" | cut -d'=' -f2`
+
+function createPackage() {
+    PACKAGE_NAME=$1
+    REST=("${@:2}")
+    CMD_ARRAY=($PYTHON "$OPENWHISK_HOME/bin/wsk" --apihost "$EDGE_HOST" package update --auth "$AUTH_KEY" --shared yes "$PACKAGE_NAME" "${REST[@]}")
+    export WSK_CONFIG_FILE= # override local property file to avoid namespace clashes
+    "${CMD_ARRAY[@]}" &
+    PID=$!
+    PIDS+=($PID)
+    echo "Creating package $PACKAGE_NAME with pid $PID"
+}
+
+function install() {
+    RELATIVE_PATH=$1
+    ACTION_NAME=$2
+    REST=("${@:3}")
+    CMD_ARRAY=($PYTHON "$OPENWHISK_HOME/bin/wsk" --apihost "$EDGE_HOST" action update --auth "$AUTH_KEY" --shared yes "$ACTION_NAME" "$RELATIVE_PATH" "${REST[@]}")
+    export WSK_CONFIG_FILE= # override local property file to avoid namespace clashes
+    "${CMD_ARRAY[@]}" &
+    PID=$!
+    PIDS+=($PID)
+    echo "Installing $ACTION_NAME with pid $PID"
+}
+
+function runPackageInstallScript() {
+    "$1/$2" &
+    PID=$!
+    PIDS+=($PID)
+    echo "Installing package $2 with pid $PID"
+}
+
+# PIDS is the list of ongoing processes and ERRORS the total number of processes that failed
+PIDS=()
+ERRORS=0
+
+# Waits for all processes in PIDS and clears it - updating ERRORS for each non-zero status code
+function waitForAll() {
+    for pid in ${PIDS[@]}; do
+        wait $pid
+        STATUS=$?
+        echo "$pid finished with status $STATUS"
+        if [ $STATUS -ne 0 ]
+        then
+            let ERRORS=ERRORS+1
+        fi
+    done
+    PIDS=()
+}


### PR DESCRIPTION
This patch is the first step to move the calalog from OpenWhisk
to OpenWhisk-catalog, consisting of the movement of all the install
scripts and util under openwhisk/catalog into
openwhisk-catalog/packages.

An additional folder named packages-test is added as well. Please
refer to the README.md under it for more information on the tests.

Closes-Bug: #4