### PR TITLE
Add the link to the instructions of packages tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # openwhisk-catalog
+
 Staging place to move out the catalog from openwhisk
+
+Check the following link for tests.
+
+* [Tests of catalogs](packages-test/README.md)


### PR DESCRIPTION
The developers can view the link to the test instructions.