### PR TITLE
Change the location of SlackTests

### DIFF
--- a/tests/src/packages/slack/SlackTests.java
+++ b/tests/src/packages/slack/SlackTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package packages;
+package packages.slack;
 
 import static common.Pair.make;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
The test folder is supposed to have the same structure as the
ockages, so SlackTests should be put under slack folder.