### PR TITLE
Retrive the openwhisk_home variable in a correct way

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,4 +1,4 @@
-def whiskhome = "$System.env.OPENWHISK_HOME"
+def whiskhome = System.getenv("OPENWHISK_HOME")
 def test_common = whiskhome + '/tests/build/classes/test'
 
 apply plugin: 'scala'


### PR DESCRIPTION
Closes-Bug: #64

System.getenv("OPENWHISK_HOME") is the general way to get the
env variable OPENWHISK_HOME.