### PR TITLE
Add wipe into the build process for Travis CI

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -20,6 +20,7 @@ $ANSIBLE_CMD setup.yml
 $ANSIBLE_CMD prereq.yml
 $ANSIBLE_CMD couchdb.yml
 $ANSIBLE_CMD initdb.yml
+$ANSIBLE_CMD wipe.yml
 
 cd $WHISKDIR
 


### PR DESCRIPTION
OpenWhisk experienced a recent change, that we need to add
"ansible-playbook -i environments/local wipe.yml"
into the build process in order to make the catalog able to install.