### PR TITLE
Remove the test cases about action creation in nodejs and nodejs 6

### DIFF
--- a/tests/src/packages/samples/CurlTest.scala
+++ b/tests/src/packages/samples/CurlTest.scala
@@ -42,34 +42,4 @@ class CurlTest extends TestHelpers with WskTestHelpers with JsHelpers {
             _.fields("response").toString should include (expectedBody)
         }
     }
-
-    it should "Return the web content when sending the public google as the payload on nodejs" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val expectedBody = "<HTML>"
-            val file = Some(new File(catalogDir, path).toString())
-            val actionName = "curlNodejs"
-
-            assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
-                action.create(name = actionName, artifact = file, kind = Some("nodejs"))
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(actionName, Map("payload" -> "google.com".toJson))) {
-                _.fields("response").toString should include(expectedBody)
-            }
-    }
-
-    it should "Return the web content when sending the public google as the payload on nodejs 6" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val expectedBody = "<HTML>"
-            val file = Some(new File(catalogDir, path).toString())
-            val actionName = "curlNodejs6"
-
-            assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
-                action.create(name = actionName, artifact = file, kind = Some("nodejs:6"))
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(actionName, Map("payload" -> "google.com".toJson))) {
-                _.fields("response").toString should include(expectedBody)
-            }
-    }
 }

--- a/tests/src/packages/samples/GreetingTest.scala
+++ b/tests/src/packages/samples/GreetingTest.scala
@@ -60,42 +60,4 @@ class GreetingTest extends TestHelpers
                     activation.getFieldPath("response", "result", "payload") should be(Some(helloMessage))
             }
     }
-
-    it should "Create an action, then return a greeting message with the name provided on Nodejs" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "greetingNodejs"
-            val file = new File(catalogDir, sample_file).toString()
-     
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(file), kind = Some("nodejs"))
-            }
-            wsk.action.get(name).stdout should include regex (""""kind": "nodejs"""")
- 
-            val run = wsk.action.invoke(name, Map("name" -> "Mork".toJson, "place" -> "Ork".toJson))
-            val helloMessage = "Hello, Mork from Ork!".toJson
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.getFieldPath("response", "success") should be (Some(true.toJson))
-                    activation.getFieldPath("response", "result", "payload") should be (Some(helloMessage))
-            }
-    }
-
-    it should "Create an action, then return a greeting message with the name provided on Nodejs 6" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "greetingNodejs"
-            val file = new File(catalogDir, sample_file).toString()
-     
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(file), kind = Some("nodejs:6"))
-            }
-            wsk.action.get(name).stdout should include regex (""""kind": "nodejs:6"""")
- 
-            val run = wsk.action.invoke(name, Map("name" -> "Mork".toJson, "place" -> "Ork".toJson))
-            val helloMessage = "Hello, Mork from Ork!".toJson
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.getFieldPath("response", "success") should be (Some(true.toJson))
-                    activation.getFieldPath("response", "result", "payload") should be (Some(helloMessage))
-            }
-    }
 }


### PR DESCRIPTION
This patch deletes the test cases of curl and greeting actions
about the action tests for nodejs and nodejs 6, since the
validity of action creation is verified in openwhisk.