### PR TITLE
Package /whisk.system/util changed to /whisk.system/utils

### DIFF
--- a/packages/samples/invoke/swift/invoke.swift
+++ b/packages/samples/invoke/swift/invoke.swift
@@ -1,7 +1,7 @@
 import SwiftyJSON
 
 func main(args: [String:Any]) -> [String:Any] {
-  let invokeResult = Whisk.invoke(actionNamed: "/whisk.system/util/date", withParameters: [:])
+  let invokeResult = Whisk.invoke(actionNamed: "/whisk.system/utils/date", withParameters: [:])
   let dateActivation = JSON(invokeResult)
 
   // the date we are looking for is the result inside the date activation


### PR DESCRIPTION
The package /whisk.system/util was changed to /whisk.system/utils in the new openwhisk-catalog repo.  The invoke.swift action needs to be updated to reflect this change.