### PR TITLE
update slack.post to support token-based auth

### DIFF
--- a/packages/installSlack.sh
+++ b/packages/installSlack.sh
@@ -17,7 +17,7 @@ createPackage slack \
 
 waitForAll
 
-install "$CATALOG_HOME/slack/post.js" \
+install "$PACKAGE_HOME/slack/post.js" \
     slack/post \
     -a description 'Post a message to Slack' \
     -a parameters '[ {"name":"text", "required":true, "description": "The message you wish to post"} ]' \

--- a/packages/installSlack.sh
+++ b/packages/installSlack.sh
@@ -12,15 +12,16 @@ source "$PACKAGE_HOME/util.sh"
 echo Installing Slack package.
 
 createPackage slack \
-    -a description "Package which contains actions to interact with the Slack messaging service"
+    -a description "This package interacts with the Slack messaging service" \
+    -a parameters '[ {"name":"username", "required":true, "bindTime":true, "description": "Your Slack username"}, {"name":"url", "required":true, "bindTime":true, "description": "Your webhook URL", "doclink": "https://api.slack.com/incoming-webhooks"},{"name":"channel", "required":true, "bindTime":true, "description": "The name of a Slack channel"}, {"name": "token", "description": "Your Slack oauth token", "doclink": "https://api.slack.com/docs/oauth"} ]'
 
 waitForAll
 
-install "$PACKAGE_HOME/slack/post.js" \
+install "$CATALOG_HOME/slack/post.js" \
     slack/post \
-    -a description 'Posts a message to Slack' \
-    -a parameters '[ {"name":"username", "required":true, "bindTime":true}, {"name":"text", "required":true}, {"name":"url", "required":true, "bindTime":true},{"name":"channel", "required":true, "bindTime":true} ]' \
-    -a sampleInput '{"username":"whisk", "text":"Hello whisk!", "channel":"myChannel", "url": "https://hooks.slack.com/services/XYZ/ABCDEFG/12345678"}'
+    -a description 'Post a message to Slack' \
+    -a parameters '[ {"name":"text", "required":true, "description": "The message you wish to post"} ]' \
+    -a sampleInput '{"username":"openwhisk", "text":"Hello OpenWhisk!", "channel":"myChannel", "url": "https://hooks.slack.com/services/XYZ/ABCDEFG/12345678"}'
 
 waitForAll
 

--- a/packages/slack/post.js
+++ b/packages/slack/post.js
@@ -14,22 +14,43 @@ function main(params) {
   var body = {
     channel: params.channel,
     username: params.username || 'Simple Message Bot',
-    text: params.text,
-    icon_emoji: params.icon_emoji
+    text: params.text
   };
+
+  if (params.icon_emoji) {
+    // guard against sending icon_emoji: undefined
+    body.icon_emoji = params.icon_emoji;
+  }
+
+  if (params.token) {
+    //
+    // this allows us to support /api/chat.postMessage
+    // e.g. users can pass params.url = https://slack.com/api/chat.postMessage
+    //                 and params.token = <their auth token>
+    //
+    body.token = params.token;
+  } else {
+    //
+    // the webhook api expects a nested payload
+    //
+    // notice that we need to stringify; this is due to limitations
+    // of the formData npm: it does not handle nested objects
+    //
+    console.log(body);
+    console.log("to: " + params.url);
+
+    body = {
+      payload: JSON.stringify(body)
+    };
+  }
 
   if (params.attachments) {
     body.attachments = params.attachments;
   }
 
-  console.log(body);
-  console.log("to: " + params.url);
-
   request.post({
     url: params.url,
-    formData: {
-      payload: JSON.stringify(body)
-    }
+    formData: body
   }, function(err, res, body) {
     if (err) {
       console.log('error: ', err, body);

--- a/tests/src/packages/slack/SlackTests.scala
+++ b/tests/src/packages/slack/SlackTests.scala
@@ -34,7 +34,6 @@ class SlackTests extends TestHelpers
   val expectedChannel = "channel: '" + channel + "'"
   val expectedUsername = "username: '" + username + "'";
   val expectedText = "text: '" + text + "'";
-  val expectedIcon = "icon_emoji: undefined";
 
   it should "The slack api should works" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
@@ -46,7 +45,6 @@ class SlackTests extends TestHelpers
           logs should include(expectedChannel)
           logs should include(expectedUsername)
           logs should include(expectedText)
-          logs should include(expectedIcon)
           logs should include(url)
       }
   }


### PR DESCRIPTION
This PR updates slack.post to support slack's oauth token style of authentication. If params.token is defined, the post assumes it is using token style authentication.

The only minor complexity here lies in the format of the body that slack expects, combined with some limitations of the formData npm that the request npm uses. The (preexisting) webhook-style API expects the formData to have the form { payload: body }, whereas the slack API expects it to be of the form body, i.e. no payload wrapper. On top of this, the formData npm cannot tolerate nested objects -- this is why the slack.post code has always called JSON.stringify on the body. This is not needed (and causes harm) for the slack API-style of invocation.

Next, I removed the icon_emoji from the body if it is not defined by params. formData also barfs on undefined. This required updating the test to remove the expectation of seeing icon_emoji in the output.

The last change to the post.js code: I pulled the console.log calls so that they'd only execute in the webhook code path, in order to avoid leaking an unredacted auth token to the logs.

I also updated the docs/catalog.md to describe the new token-based auth support.

Finally, I updated installSlack to add description and doclink fields. Here, I hoisted the bindTime parameters from the action annotation to the level of a package annotation. This has been a long-standing issue with the slack metadata that forced the Bluemix UI code to have some hacks: i.e. when prompting the user for a package binding, we had to hackishly look at the action annotations, even though the user had requested to make a package binding -- an operation independent of any action.

closes #121 