### PR TITLE
update installGit.sh to improve description, doclink, and sampleInput

### DIFF
--- a/packages/installGit.sh
+++ b/packages/installGit.sh
@@ -19,9 +19,9 @@ waitForAll
 install "$PACKAGE_HOME/github/webhook.js" \
     github/webhook \
     -a feed true \
-    -a description 'Creates a webhook on github to be notified on selected changes' \
-    -a parameters '[ {"name":"username", "required":true, "bindTime":true}, {"name":"repository", "required":true, "bindTime":true}, {"name":"accessToken", "required":true, "bindTime":true},{"name":"events", "required":true} ]' \
-    -a sampleInput '{"username":"whisk", "repository":"WhiskRepository", "accessToken":"123ABCXYZ", "events": "push,commit,delete"}'
+    -a description 'Creates a webhook on GitHub to be notified on selected changes' \
+    -a parameters '[ {"name":"username", "required":true, "bindTime":true, "description": "Your GitHub username"}, {"name":"repository", "required":true, "bindTime":true, "description": "The name of a GitHub repository"}, {"name":"accessToken", "required":true, "bindTime":true, "description": "A webhook or personal token", "doclink": "https://github.com/settings/tokens/new"},{"name":"events", "required":true, "description": "A comma-separated list", "doclink": "https://developer.github.com/webhooks/#events"} ]' \
+    -a sampleInput '{"username":"myUserName", "repository":"myRepository or myOrganization/myRepository", "accessToken":"123ABCXYZ", "events": "push,delete,pull-request"}'
 
 waitForAll
 


### PR DESCRIPTION
This PR does the following:
1) fixes the main description to render the provider name more accurately as "GitHub", rather than the previous "github"
2) adds field-level descriptions to web hook
3) adds a doclink attribute to the accessToken and events fields

closes https://github.com/openwhisk/openwhisk-catalog/issues/123

(c.f. https://github.com/openwhisk/openwhisk/pull/1103)