### PR TITLE
GitHub webhook delete

### DIFF
--- a/packages/github/webhook.js
+++ b/packages/github/webhook.js
@@ -27,12 +27,11 @@ function main(params) {
     }
   }
 
-  var endpoint = 'openwhisk.ng.bluemix.net';
   var lifecycleEvent = params.lifecycleEvent;
   var triggerName = params.triggerName.split("/");
 
     // URL of the whisk system. The calls of github will go here.
-  var whiskCallbackUrl = 'https://' + whisk.getAuthKey() + "@" + endpoint + '/api/v1/namespaces/' + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
+  var whiskCallbackUrl = 'https://' + whisk.getAuthKey() + "@" + params.endpoint + '/api/v1/namespaces/' + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
 
     // The URL to create the webhook on Github
   var registrationEndpoint = 'https://api.github.com/repos/' + (organization ? organization : username) + '/' + repository + '/hooks';
@@ -83,6 +82,83 @@ function main(params) {
             });
           } else {
             resolve({response: body});
+          }
+        }
+      });
+    });
+
+    return promise;
+  } else if(lifecycleEvent === 'DELETE') {
+    //list all the existing webhooks first.
+    var options = {
+        method: 'GET',
+        url: registrationEndpoint,
+        json: true,
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': authorizationHeader,
+            'User-Agent': 'whisk'
+        }
+    }
+
+    var promise = new Promise(function(resolve, reject) {
+      request(options, function(error, response, body){
+        // the URL that comes back from GitHub does not include auth info
+        var foundWebhookToDelete = false;
+
+        if (error){
+          reject({
+            response: response,
+            error:error,
+            body:body
+          });
+        } else {
+          for(i=0; i<body.length;i++){
+              if (decodeURI(body[i].config.url) === whiskCallbackUrl) {
+                  foundWebhookToDelete = true;
+
+                  console.log('DELETE Webhook URL: ' + body[i].url);
+                  var options = {
+                      method: 'DELETE',
+                      url: body[i].url,
+                      headers: {
+                          'Content-Type': 'application/json',
+                          'Authorization': authorizationHeader,
+                          'User-Agent': 'whisk'
+                      }
+                  }
+
+                  request(options, function(error, response, body) {
+                      if (error) {
+                          whisk.error({
+                            response: response,
+                            error:error,
+                            body:body
+                          });
+                      } else {
+                          console.log("Status code: " + response.statusCode);
+                          if(response.statusCode >= 400) {
+                              console.log("Response from Github: " + body);
+
+                              // a 404 is common and confusing enough to warrant an extra message
+                              if(response.statusCode === 404) {
+                                console.log('Please ensure your accessToken is authorized to delete webhooks.');
+                              }
+
+                              reject({
+                                  statusCode: response.statusCode,
+                                  response: body
+                              });
+                          } else {
+                            resolve();
+                          }
+                      }
+                  });
+              }
+          }
+
+          if(!foundWebhookToDelete) {
+            reject('Found no existing webhooks for trigger URL ' + whiskCallbackUrl);
           }
         }
       });

--- a/packages/installGit.sh
+++ b/packages/installGit.sh
@@ -12,6 +12,7 @@ source "$PACKAGE_HOME/util.sh"
 echo Installing Git package.
 
 createPackage github \
+    -p endpoint "openwhisk.ng.bluemix.net"
     -a description "Package which contains actions and feeds to interact with Github"
 
 waitForAll


### PR DESCRIPTION
Implement the `DELETE` lifecycle event for GitHub triggers.

This is based off the work originally contributed by @lzbj to openwhisk/openwhisk#742 as commit [a287e4](https://github.com/openwhisk/openwhisk/pull/742/commits/a287e4d766dcedb1a5e2f8f87ba244cb4148c07b)