### PR TITLE
Refactor the Watson packages and actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ actions and packages.
 | `/whisk.system/samples` | offers sample actions in different languages |
 | `/whisk.system/slack` | offers a convenient way to use the [Slack APIs](https://api.slack.com/). |
 | `/whisk.system/utils` | offers utilities actions such as cat, echo, and etc. |
-| `/whisk.system/watson` | offers a convenient way to call various Watson APIs.|
+| `/whisk.system/watson-translator` | offers a convenient way to call Watson APIs to translate.|
+| `/whisk.system/watson-speechToText` | offers a convenient way to call Watson APIs to convert the speech into text.|
+| `/whisk.system/watson-textToSpeech` | offers a convenient way to call Watson APIs to convert the text into speech.|
 | `/whisk.system/weather` | offers a convenient way to call the IBM Weather Insights API.|
 
 ## How to create packages
@@ -110,25 +112,38 @@ The following is an example of creating a package binding and then getting a 10-
   ```
 
 
-## Using the Watson package
+## Using the Watson-translator package
 
-The `/whisk.system/watson` package offers a convenient way to call various Watson APIs.
+The `/whisk.system/watson-translator` package offers a convenient way to call Watson APIs to translate.
+
+
+## Using the Watson-speechToText package
+
+The `/whisk.system/watson-speechToText` package offers a convenient way to call Watson APIs to convert the speech into text.
+
+
+## Using the Watson-textToSpeech package
+
+The `/whisk.system/watson-textToSpeech` package offers a convenient way to call Watson APIs to convert the text into speech.
+
 
 The package includes the following actions.
 
 | Entity | Type | Parameters | Description |
 | --- | --- | --- | --- |
-| `/whisk.system/watson` | package | username, password | Actions for the Watson analytics APIs |
-| `/whisk.system/watson/translate` | action | translateFrom, translateTo, translateParam, username, password | Translate text |
-| `/whisk.system/watson/languageId` | action | payload, username, password | Identify language |
-| `/whisk.system/watson/speechToText` | action | payload, content_type, encoding, username, password, continuous, inactivity_timeout, interim_results, keywords, keywords_threshold, max_alternatives, model, timestamps, watson-token, word_alternatives_threshold, word_confidence, X-Watson-Learning-Opt-Out | Convert audio into text |
-| `/whisk.system/watson/textToSpeech` | action | payload, voice, accept, encoding, username, password | Convert text into audio |
+| `/whisk.system/watson-translator` | package | username, password | Actions for the Watson analytics APIs to translate |
+| `/whisk.system/watson-speechToText` | package | username, password | Actions for the Watson analytics APIs to convert the speech into text |
+| `/whisk.system/watson-textToSpeech` | package | username, password | Actions for the Watson analytics APIs to convert the text into speech |
+| `/whisk.system/watson-translator/translator` | action | translateFrom, translateTo, translateParam, username, password | Translate text |
+| `/whisk.system/watson-translator/languageId` | action | payload, username, password | Identify language |
+| `/whisk.system/watson-speechToText/speechToText` | action | payload, content_type, encoding, username, password, continuous, inactivity_timeout, interim_results, keywords, keywords_threshold, max_alternatives, model, timestamps, watson-token, word_alternatives_threshold, word_confidence, X-Watson-Learning-Opt-Out | Convert audio into text |
+| `/whisk.system/watson-textToSpeech/textToSpeech` | action | payload, voice, accept, encoding, username, password | Convert text into audio |
 
 Creating a package binding with the `username` and `password` values is suggested. This way, you don't need to specify these credentials every time you invoke the actions in the package.
 
 ### Translating text
 
-The `/whisk.system/watson/translate` action translates text from one language to another. The parameters are as follows:
+The `/whisk.system/watson-translator/translator` action translates text from one language to another. The parameters are as follows:
 
 - `username`: The Watson API user name.
 - `password`: The Watson API password.
@@ -141,13 +156,13 @@ The following is an example of creating a package binding and translating some t
 1. Create a package binding with your Watson credentials.
 
   ```
-  $ wsk package bind /whisk.system/watson myWatson --param username 'MY_WATSON_USERNAME' --param password 'MY_WATSON_PASSWORD'
+  $ wsk package bind /whisk.system/watson-translator myWatson --param username 'MY_WATSON_USERNAME' --param password 'MY_WATSON_PASSWORD'
   ```
 
-2. Invoke the `translate` action in your package binding to translate some text from English to French.
+2. Invoke the `translator` action in your package binding to translate some text from English to French.
 
   ```
-  $ wsk action invoke myWatson/translate --blocking --result --param payload 'Blue skies ahead' --param translateParam 'payload' --param translateFrom 'en' --param translateTo 'fr'
+  $ wsk action invoke myWatson/translator --blocking --result --param payload 'Blue skies ahead' --param translateParam 'payload' --param translateFrom 'en' --param translateTo 'fr'
   ```
 
   ```
@@ -159,7 +174,7 @@ The following is an example of creating a package binding and translating some t
 
 ### Identifying the language of some text
 
-The `/whisk.system/watson/languageId` action identifies the language of some text. The parameters are as follows:
+The `/whisk.system/watson-translator/languageId` action identifies the language of some text. The parameters are as follows:
 
 - `username`: The Watson API user name.
 - `password`: The Watson API password.
@@ -170,7 +185,7 @@ The following is an example of creating a package binding and identifying the la
 1. Create a package binding with your Watson credentials.
 
   ```
-  $ wsk package bind /whisk.system/watson myWatson -p username 'MY_WATSON_USERNAME' -p password 'MY_WATSON_PASSWORD'
+  $ wsk package bind /whisk.system/watson-translator myWatson -p username 'MY_WATSON_USERNAME' -p password 'MY_WATSON_PASSWORD'
   ```
 
 2. Invoke the `languageId` action in your package binding to identify the language.
@@ -189,7 +204,7 @@ The following is an example of creating a package binding and identifying the la
 
 ### Converting some text to speech
 
-The `/whisk.system/watson/textToSpeech` action converts some text into an audio speech. The parameters are as follows:
+The `/whisk.system/watson-speechToText/textToSpeech` action converts some text into an audio speech. The parameters are as follows:
 
 - `username`: The Watson API user name.
 - `password`: The Watson API password.
@@ -203,7 +218,7 @@ The following is an example of creating a package binding and converting some te
 1. Create a package binding with your Watson credentials.
 
   ```
-  $ wsk package bind /whisk.system/watson myWatson -p username 'MY_WATSON_USERNAME' -p password 'MY_WATSON_PASSWORD'
+  $ wsk package bind /whisk.system/watson-speechToText myWatson -p username 'MY_WATSON_USERNAME' -p password 'MY_WATSON_PASSWORD'
   ```
 
 2. Invoke the `textToSpeech` action in your package binding to convert the text.
@@ -220,7 +235,7 @@ The following is an example of creating a package binding and converting some te
 
 ### Converting speech to text
 
-The `/whisk.system/watson/speechToText` action converts audio speech into text. The parameters are as follows:
+The `/whisk.system/watson-speechToText/speechToText` action converts audio speech into text. The parameters are as follows:
 
 - `username`: The Watson API user name.
 - `password`: The Watson API password.
@@ -245,7 +260,7 @@ The following is an example of creating a package binding and converting speech 
 1. Create a package binding with your Watson credentials.
 
   ```
-  $ wsk package bind /whisk.system/watson myWatson -p username 'MY_WATSON_USERNAME' -p password 'MY_WATSON_PASSWORD'
+  $ wsk package bind /whisk.system/watson-speechToText myWatson -p username 'MY_WATSON_USERNAME' -p password 'MY_WATSON_PASSWORD'
   ```
 
 2. Invoke the `speechToText` action in your package binding to convert the encoded audio.

--- a/packages/installWatson.sh
+++ b/packages/installWatson.sh
@@ -15,6 +15,24 @@ createPackage watson \
     -a description "Actions for the Watson analytics APIs" \
     -a parameters '[ {"name":"username", "required":false}, {"name":"password", "required":false, "type":"password"} ]'
 
+createPackage watson-translator \
+    -a description "Actions for the Watson analytics APIs to translate" \
+    -a parameters '[ {"name":"bluemixServiceName", "required":false, "bindTime":true}, {"name":"username", "required":false}, {"name":"password", "required":false, "type":"password"} ]' \
+	-a tags '["watson"]' \
+	-p bluemixServiceName 'language_translator'
+
+createPackage watson-speechToText \
+    -a description "Actions for the Watson analytics APIs to convert speech into text" \
+    -a parameters '[ {"name":"bluemixServiceName", "required":false, "bindTime":true}, {"name":"username", "required":false}, {"name":"password", "required":false, "type":"password"} ]' \
+	-a tags '["watson"]' \
+	-p bluemixServiceName 'speech_to_text'
+
+createPackage watson-textToSpeech \
+    -a description "Actions for the Watson analytics APIs to convert text into speech" \
+    -a parameters '[ {"name":"bluemixServiceName", "required":false, "bindTime":true}, {"name":"username", "required":false}, {"name":"password", "required":false, "type":"password"} ]' \
+	-a tags '["watson"]' \
+	-p bluemixServiceName 'text_to_speech'
+
 waitForAll
 
 install "$PACKAGE_HOME/watson/speechToText.js" \
@@ -129,6 +147,129 @@ install "$PACKAGE_HOME/watson/languageId.js" \
 
 install "$PACKAGE_HOME/watson/textToSpeech.js" \
     watson/textToSpeech \
+    -a description 'Synthesize text to spoken audio' \
+    -a parameters '[
+        {"name":"username", "required":true, "bindTime":true, "description":"The Watson service username"},
+        {"name":"password", "required":true, "type":"password", "bindTime":true, "description":"The Watson service password"},
+        {"name":"payload", "required":true, "description":"The text to be synthesized"},
+        {"name":"voice", "required":false, "description":"The voice to be used for synthesis"},
+        {"name":"accept", "required":false, "description":"The requested MIME type of the audio"},
+        {"name":"encoding", "required":false, "description":"The encoding of the speech binary data"}]' \
+    -a sampleInput '{"payload":"Hello, world.", "encoding":"base64", "accept":"audio/wav", "voice":"en-US_MichaelVoice", "username":"XXX", "password":"XXX" }' \
+    -a sampleOutput '{"payload":"<base64 encoding of a .wav file>", "encoding":"base64", "mimetype":"audio/wav"}'
+
+install "$PACKAGE_HOME/watson-speechToText/speechToText.js" \
+    watson-speechToText/speechToText \
+    -a description 'Convert speech to text' \
+    -a parameters '[
+  {
+    "name": "content_type",
+    "required": true,
+    "description": "The MIME type of the audio"
+  },
+  {
+    "name": "model",
+    "required": false,
+    "description": "The identifier of the model to be used for the recognition request"
+  },
+  {
+    "name": "continuous",
+    "required": false,
+    "description": "Indicates whether multiple final results that represent consecutive phrases separated by long pauses are returned"
+  },
+  {
+    "name": "inactivity_timeout",
+    "required": false,
+    "description": "The time in seconds after which, if only silence (no speech) is detected in submitted audio, the connection is closed"
+  },
+  {
+    "name": "interim_results",
+    "required": false,
+    "description": "Indicates whether the service is to return interim results"
+  },
+  {
+    "name": "keywords",
+    "required": false,
+    "description": "A list of keywords to spot in the audio"
+  },
+  {
+    "name": "keywords_threshold",
+    "required": false,
+    "description": "A confidence value that is the lower bound for spotting a keyword"
+  },
+  {
+    "name": "max_alternatives",
+    "required": false,
+    "description": "The maximum number of alternative transcripts to be returned"
+  },
+  {
+    "name": "word_alternatives_threshold",
+    "required": false,
+    "description": "A confidence value that is the lower bound for identifying a hypothesis as a possible word alternative"
+  },
+  {
+    "name": "word_confidence",
+    "required": false,
+    "description": "Indicates whether a confidence measure in the range of 0 to 1 is to be returned for each word"
+  },
+  {
+    "name": "timestamps",
+    "required": false,
+    "description": "Indicates whether time alignment is returned for each word"
+  },
+  {
+    "name": "X-Watson-Learning-Opt-Out",
+    "required": false,
+    "description": "Indicates whether to opt out of data collection for the call"
+  },
+  {
+    "name": "watson-token",
+    "required": false,
+    "description": "Provides an authentication token for the service as an alternative to providing service credentials"
+  },
+  {
+    "name": "encoding",
+    "required": true,
+    "description": "The encoding of the speech binary data"
+  },
+  {
+    "name": "payload",
+    "required": true,
+    "description": "The encoding of the speech binary data"
+  },
+  {
+    "name": "username",
+    "required": true,
+    "bindTime": true,
+    "description": "The Watson service username"
+  },
+  {
+    "name": "password",
+    "required": true,
+    "type": "password",
+    "bindTime": true,
+    "description": "The Watson service password"
+  }
+]' \
+    -a sampleInput '{"payload":"<base64 encoding of a wav file>", "encoding":"base64", "content_type":"audio/wav", "username":"XXX", "password":"XXX"}' \
+    -a sampleOutput '{"data":"Hello."}'
+
+install "$PACKAGE_HOME/watson-translator/translator.js" \
+    watson-translator/translator \
+    -a description 'Translate text' \
+    -a parameters '[ {"name":"translateFrom", "required":false}, {"name":"translateTo", "required":false}, {"name":"payload", "required":false}, {"name":"username", "required":true, "bindTime":true}, {"name":"password", "required":true, "type":"password", "bindTime":true} ]' \
+    -a sampleInput '{"translateFrom":"en", "translateTo":"fr", "payload":"Hello", "username":"XXX", "password":"XXX"}' \
+    -a sampleOutput '{"payload":"Bonjour"}'
+
+install "$PACKAGE_HOME/watson-translator/languageId.js" \
+    watson-translator/languageId \
+    -a description 'Identify language' \
+    -a parameters '[ {"name":"username", "required":true, "bindTime":true}, {"name":"password", "required":true, "type":"password", "bindTime":true}, {"name":"payload", "required":true} ]' \
+    -a sampleInput '{"payload": "Bonjour", "username":"XXX", "password":"XXX"}' \
+    -a sampleOutput '{"language": "French", "confidence": 1}'
+
+install "$PACKAGE_HOME/watson-textToSpeech/textToSpeech.js" \
+    watson-textToSpeech/textToSpeech \
     -a description 'Synthesize text to spoken audio' \
     -a parameters '[
         {"name":"username", "required":true, "bindTime":true, "description":"The Watson service username"},

--- a/packages/watson-speechToText/speechToText.js
+++ b/packages/watson-speechToText/speechToText.js
@@ -1,0 +1,121 @@
+var watson = require('watson-developer-cloud');
+var fs = require('fs');
+var stream = require('stream');
+
+function isValidEncoding(encoding) {
+  return encoding === 'ascii' ||
+    encoding === 'utf8' ||
+    encoding === 'utf16le' ||
+    encoding === 'ucs2' ||
+    encoding === 'base64' ||
+    encoding === 'binary' ||
+    encoding === 'hex';
+}
+
+/**
+ * Transcribes speech from various languages and audio formats to text
+ * See https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/speech-to-text/api/v1/#recognize_audio_websockets
+ *
+ * @param content_type The MIME type of the audio. Required.
+ * @param model The identifier of the model to be used for the recognition request.
+ * @param continuous Indicates whether multiple final results that represent consecutive phrases separated by long pauses are returned.
+ * @param inactivity_timeout The time in seconds after which, if only silence (no speech) is detected in submitted audio, the connection is closed. The default is 30 seconds.
+ * @param interim_results	Indicates whether the service is to return interim results.
+ * @param keywords A list of keywords to spot in the audio.
+ * @param keywords_threshold A confidence value that is the lower bound for spotting a keyword.
+ * @param max_alternatives The maximum number of alternative transcripts to be returned.
+ * @param word_alternatives_threshold A confidence value that is the lower bound for identifying a hypothesis as a possible word alternative.
+ * @param word_confidence Indicates whether a confidence measure in the range of 0 to 1 is to be returned for each word.
+ * @param timestamps Indicates whether time alignment is returned for each word.
+ * @param X-Watson-Learning-Opt-Out	Indicates whether to opt out of data collection for the call.
+ * @param watson-token Provides an authentication token for the service as an alternative to providing service credentials.
+ * @param encoding The encoding of the speech binary data. Required.
+ * @param payload The encoded data to turn into text. Required.
+ * @param username The Watson service username.
+ * @param password The Watson service password.
+ *
+ * @return {
+ *  "data": "Final results for the request",
+ *  "results": "Interim results for the request"
+ *  "error": "Errors for the connection"
+ * }
+ */
+function main(params) {
+  var payload = params.payload;
+  var encoding = params.encoding;
+  var username = params.username;
+  var password = params.password;
+
+  console.log('params:', params);
+
+  if (!payload) {
+    return {
+      'error': 'No payload specified.'
+    };
+  } else if (!isValidEncoding(encoding)) {
+    return {
+      'error': 'Not a valid encoding.'
+    };
+  }
+
+  var response = {};
+  var speechToText = watson.speech_to_text({
+    username: username,
+    password: password,
+    version: 'v1'
+  });
+
+  // Create the stream.
+  var recognizeStream = speechToText.createRecognizeStream({
+    content_type: params.content_type,
+    model: params.model,
+    continuous: params.continuous,
+    inactivity_timeout: params.inactivity_timeout,
+    interim_results: params.interim_results,
+    keywords: params.keywords,
+    max_alternatives: params.max_alternatives,
+    word_alternatives_threshold: params.word_alternatives_threshold,
+    word_confidence: params.word_confidence,
+    timestamps: params.timestamps,
+    'X-Watson-Learning-Opt-Out': params['X-Watson-Learning-Opt-Out'],
+    'watson-token': params['watson-token']
+  });
+
+  // Pipe in some audio.
+  var b = Buffer(payload, encoding);
+  var s = new stream.Readable();
+  s._read = function noop() {}; // Needed to escape not implemented exception
+  s.push(b);
+  s.pipe(recognizeStream);
+  s.push(null);
+
+  // Pipe out the transcription.
+  recognizeStream.pipe(fs.createWriteStream('output'));
+
+  // Get strings instead of buffers from `data` events.
+  recognizeStream.setEncoding('utf8');
+
+  // Listen for 'data' events for only the final results.
+  // Listen for 'results' events to get interim results.
+  var promise = new Promise(function(resolve, reject) {
+    ['data', 'results', 'error', 'connection-close'].forEach(function (name) {
+      recognizeStream.on(name, function (event_) {
+        if (name === 'data') {
+          response.data = event_;
+          resolve(response);
+        } else if (name === 'results' && params.interim_results) {
+          if (!response.results)
+            response.results = [];
+          response.results.push(event_);
+        } else if (name === 'error' || name === 'connection-close') {
+          response.error = event_ && typeof(event_.toString) === 'function' ?
+              event_.toString() : 'Watson API failed';
+          resolve(response);
+        }
+      });
+    });
+  });
+
+  return promise;
+}
+

--- a/packages/watson-textToSpeech/textToSpeech.js
+++ b/packages/watson-textToSpeech/textToSpeech.js
@@ -1,0 +1,68 @@
+var watson = require('watson-developer-cloud');
+
+function isValidEncoding(encoding) {
+  return encoding === 'ascii' ||
+    encoding === 'utf8' ||
+    encoding === 'utf16le' ||
+    encoding === 'ucs2' ||
+    encoding === 'base64' ||
+    encoding === 'binary' ||
+    encoding === 'hex';
+}
+
+/**
+ * Synthesizes text to spoken audio.
+ * See https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/text-to-speech/api/v1/
+ *
+ * @param voice The voice to be used for synthesis. Example: en-US_MichaelVoice
+ * @param accept The requested MIME type of the audio. Example: audio/wav
+ * @param payload The text to synthesized. Required.
+ * @param encoding The encoding of the speech binary data. Defaults to base64.
+ * @param username The Watson service username.
+ * @param password The Watson service password.
+ *
+ * @return {
+ *  "payload": "<encoded speech file>",
+ *  "encoding": "<encoding of payload>",
+ *  "content_type": "<content_type of payload>"
+ * }
+ */
+function main(params) {
+  var voice = params.voice;
+  var accept = params.accept;
+  var payload = params.payload;
+  var encoding = isValidEncoding(params.encoding) ? params.encoding : 'base64';
+  var username = params.username;
+  var password = params.password;
+
+  console.log('params:', params);
+
+  var textToSpeech = watson.text_to_speech({
+    username: username,
+    password: password,
+    version: 'v1'
+  });
+
+  var promise = new Promise(function(resolve, reject) {
+    textToSpeech.synthesize({
+      voice: voice,
+      accept: accept,
+      text: payload,
+    }, function (err, res) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve({
+          payload: res.toString(encoding),
+          encoding: encoding,
+          mimetype: accept
+        });
+      }
+    }, function (err) {
+      reject(err);
+    });
+  });
+
+  return promise;
+}
+

--- a/packages/watson-translator/languageId.js
+++ b/packages/watson-translator/languageId.js
@@ -1,0 +1,42 @@
+var watson = require('watson-developer-cloud/language-translator/v2');
+
+/**
+ * Identify the language of some text.
+ *
+ * @param payload The text to identify.
+ * @param username The watson service username.
+ * @param password The watson service password.
+ * @return An object with the following properties: {
+ *           payload: the original text,
+ *           language: the identified language,
+ *           confidence: the confidence score
+ *         }
+ */
+function main({payload: payload,
+	username: username,
+	password: password,
+	url: url = 'https://gateway.watsonplatform.net/language-translator/api'
+		}) {
+	console.log('payload is', payload);
+    var language_translation = new watson({
+        username: username,
+        password: password,
+        url: url
+    });
+    var promise = new Promise(function(resolve, reject) {
+        language_translation.identify({text: payload}, function (err, response) {
+            if (err) {
+                console.log('error:', err);
+                reject(err);
+            } else {
+                var language = response.languages[0].language;
+                var confidence = response.languages[0].confidence;
+                console.log('language:', language, ', payload:', payload);
+                resolve({language: language, payload: payload, confidence: confidence});
+            }
+        });
+    });
+
+    return promise;
+}
+

--- a/packages/watson-translator/translator.js
+++ b/packages/watson-translator/translator.js
@@ -1,0 +1,214 @@
+var watson = require('watson-developer-cloud/language-translator/v2');
+
+/**
+ * Translate a string from one language to another.
+ *
+ * @param translateFrom The two digit code of the language to translate from.
+ * @param translateTo The two digit code of the language to translate to.
+ * @param translateParam The input parameter to translate. Defaults to 'payload'.
+ * @param username The Watson service username.
+ * @param password The Watson service password.
+ * @return The translateParam parameter with all values translated, or error if
+ * Watson service returns error
+ */
+function main(params) {
+    console.log('params:', params);
+
+    var from = params.translateFrom || 'en';
+    var to = params.translateTo || 'fr';
+    var translateParam = params.translateParam || 'payload';
+    var url = params.url || 'https://gateway.watsonplatform.net/language-translator/api';
+    var input = {};
+    input[translateParam] = params[translateParam];
+
+    var texts = getTextsToTranslate(input);
+    var promise = new Promise(function(resolve, reject) {
+        doTranslateTexts(texts, from, to, params.username, params.password, url, function (error, translatedTexts) {
+
+            if (error) {
+                reject(error);
+            } else {
+                var output = setTranslatedTexts(input, {translatedTexts: translatedTexts});
+                console.log('output:', JSON.stringify(output));
+                resolve(output);
+            }
+        });
+    });
+
+    return promise;
+}
+
+/**
+ * Return all the string values in an object.
+ *
+ * This will recursively traverse the object.
+ */
+function getTextsToTranslate(obj) {
+    var texts = [];
+    if (typeof obj === 'string') {
+        texts.push(obj);
+    } else if (typeof obj === 'object') {
+        for (var e in obj) {
+            var value = obj[e];
+            if (typeof value === 'string')
+                texts.push(value);
+            else if (typeof value === 'object')
+                texts = texts.concat(getTextsToTranslate(value));
+        }
+    }
+    return texts;
+}
+
+/**
+ * Set the string values in an object to the translated values.
+ *
+ * This will recursively traverse the object.
+ */
+function setTranslatedTexts(obj, translations) {
+    var translatedTexts = translations.translatedTexts || [];
+    var i = translations.start || 0;
+    if (typeof obj === 'string') {
+        obj = translatedTexts[i++];
+    } else if (typeof obj === 'object') {
+        for (var e in obj) {
+            var value = obj[e];
+            if (typeof value === 'string') {
+                obj[e] = translatedTexts[i++];
+            } else if (typeof value === 'object') {
+                var translations = {translatedTexts: translatedTexts, start: i};
+                setTranslatedTexts(value, translations);
+                i = translations.start;
+            }
+        }
+    }
+    translations.start = i;
+    return obj;
+}
+
+/**
+ * Translate an array of strings.
+ */
+function doTranslateTexts(texts, from, to, username, password, url, next) {
+    var translated = [];
+    var language_translation = new watson({
+        username: username,
+        password: password,
+        url: url
+    });
+    var options = { text: texts, source: from, target: to };
+    language_translation.translate(options, function (err, response) {
+        if (err) {
+            console.log('error:', err);
+            if (next) next(err, null)
+        } else {
+            var translation = response.translations[0].translation;
+            //console.log('response:', response);
+            for (var e in response.translations) {
+                translated.push(removeDiacritics(response.translations[e].translation));
+            }
+        }
+        if (next) next(null, translated);
+    });
+}
+
+/**
+ * Return a string with diacritics removed.
+ * From http://web.archive.org/web/20120918093154/http://lehelk.com/2011/05/06/script-to-remove-diacritics
+ */
+function removeDiacritics (str) {
+
+  var defaultDiacriticsRemovalMap = [
+    {'base':'A', 'letters':/[\u0041\u24B6\uFF21\u00C0\u00C1\u00C2\u1EA6\u1EA4\u1EAA\u1EA8\u00C3\u0100\u0102\u1EB0\u1EAE\u1EB4\u1EB2\u0226\u01E0\u00C4\u01DE\u1EA2\u00C5\u01FA\u01CD\u0200\u0202\u1EA0\u1EAC\u1EB6\u1E00\u0104\u023A\u2C6F]/g},
+    {'base':'AA','letters':/[\uA732]/g},
+    {'base':'AE','letters':/[\u00C6\u01FC\u01E2]/g},
+    {'base':'AO','letters':/[\uA734]/g},
+    {'base':'AU','letters':/[\uA736]/g},
+    {'base':'AV','letters':/[\uA738\uA73A]/g},
+    {'base':'AY','letters':/[\uA73C]/g},
+    {'base':'B', 'letters':/[\u0042\u24B7\uFF22\u1E02\u1E04\u1E06\u0243\u0182\u0181]/g},
+    {'base':'C', 'letters':/[\u0043\u24B8\uFF23\u0106\u0108\u010A\u010C\u00C7\u1E08\u0187\u023B\uA73E]/g},
+    {'base':'D', 'letters':/[\u0044\u24B9\uFF24\u1E0A\u010E\u1E0C\u1E10\u1E12\u1E0E\u0110\u018B\u018A\u0189\uA779]/g},
+    {'base':'DZ','letters':/[\u01F1\u01C4]/g},
+    {'base':'Dz','letters':/[\u01F2\u01C5]/g},
+    {'base':'E', 'letters':/[\u0045\u24BA\uFF25\u00C8\u00C9\u00CA\u1EC0\u1EBE\u1EC4\u1EC2\u1EBC\u0112\u1E14\u1E16\u0114\u0116\u00CB\u1EBA\u011A\u0204\u0206\u1EB8\u1EC6\u0228\u1E1C\u0118\u1E18\u1E1A\u0190\u018E]/g},
+    {'base':'F', 'letters':/[\u0046\u24BB\uFF26\u1E1E\u0191\uA77B]/g},
+    {'base':'G', 'letters':/[\u0047\u24BC\uFF27\u01F4\u011C\u1E20\u011E\u0120\u01E6\u0122\u01E4\u0193\uA7A0\uA77D\uA77E]/g},
+    {'base':'H', 'letters':/[\u0048\u24BD\uFF28\u0124\u1E22\u1E26\u021E\u1E24\u1E28\u1E2A\u0126\u2C67\u2C75\uA78D]/g},
+    {'base':'I', 'letters':/[\u0049\u24BE\uFF29\u00CC\u00CD\u00CE\u0128\u012A\u012C\u0130\u00CF\u1E2E\u1EC8\u01CF\u0208\u020A\u1ECA\u012E\u1E2C\u0197]/g},
+    {'base':'J', 'letters':/[\u004A\u24BF\uFF2A\u0134\u0248]/g},
+    {'base':'K', 'letters':/[\u004B\u24C0\uFF2B\u1E30\u01E8\u1E32\u0136\u1E34\u0198\u2C69\uA740\uA742\uA744\uA7A2]/g},
+    {'base':'L', 'letters':/[\u004C\u24C1\uFF2C\u013F\u0139\u013D\u1E36\u1E38\u013B\u1E3C\u1E3A\u0141\u023D\u2C62\u2C60\uA748\uA746\uA780]/g},
+    {'base':'LJ','letters':/[\u01C7]/g},
+    {'base':'Lj','letters':/[\u01C8]/g},
+    {'base':'M', 'letters':/[\u004D\u24C2\uFF2D\u1E3E\u1E40\u1E42\u2C6E\u019C]/g},
+    {'base':'N', 'letters':/[\u004E\u24C3\uFF2E\u01F8\u0143\u00D1\u1E44\u0147\u1E46\u0145\u1E4A\u1E48\u0220\u019D\uA790\uA7A4]/g},
+    {'base':'NJ','letters':/[\u01CA]/g},
+    {'base':'Nj','letters':/[\u01CB]/g},
+    {'base':'O', 'letters':/[\u004F\u24C4\uFF2F\u00D2\u00D3\u00D4\u1ED2\u1ED0\u1ED6\u1ED4\u00D5\u1E4C\u022C\u1E4E\u014C\u1E50\u1E52\u014E\u022E\u0230\u00D6\u022A\u1ECE\u0150\u01D1\u020C\u020E\u01A0\u1EDC\u1EDA\u1EE0\u1EDE\u1EE2\u1ECC\u1ED8\u01EA\u01EC\u00D8\u01FE\u0186\u019F\uA74A\uA74C]/g},
+    {'base':'OI','letters':/[\u01A2]/g},
+    {'base':'OO','letters':/[\uA74E]/g},
+    {'base':'OU','letters':/[\u0222]/g},
+    {'base':'P', 'letters':/[\u0050\u24C5\uFF30\u1E54\u1E56\u01A4\u2C63\uA750\uA752\uA754]/g},
+    {'base':'Q', 'letters':/[\u0051\u24C6\uFF31\uA756\uA758\u024A]/g},
+    {'base':'R', 'letters':/[\u0052\u24C7\uFF32\u0154\u1E58\u0158\u0210\u0212\u1E5A\u1E5C\u0156\u1E5E\u024C\u2C64\uA75A\uA7A6\uA782]/g},
+    {'base':'S', 'letters':/[\u0053\u24C8\uFF33\u1E9E\u015A\u1E64\u015C\u1E60\u0160\u1E66\u1E62\u1E68\u0218\u015E\u2C7E\uA7A8\uA784]/g},
+    {'base':'T', 'letters':/[\u0054\u24C9\uFF34\u1E6A\u0164\u1E6C\u021A\u0162\u1E70\u1E6E\u0166\u01AC\u01AE\u023E\uA786]/g},
+    {'base':'TZ','letters':/[\uA728]/g},
+    {'base':'U', 'letters':/[\u0055\u24CA\uFF35\u00D9\u00DA\u00DB\u0168\u1E78\u016A\u1E7A\u016C\u00DC\u01DB\u01D7\u01D5\u01D9\u1EE6\u016E\u0170\u01D3\u0214\u0216\u01AF\u1EEA\u1EE8\u1EEE\u1EEC\u1EF0\u1EE4\u1E72\u0172\u1E76\u1E74\u0244]/g},
+    {'base':'V', 'letters':/[\u0056\u24CB\uFF36\u1E7C\u1E7E\u01B2\uA75E\u0245]/g},
+    {'base':'VY','letters':/[\uA760]/g},
+    {'base':'W', 'letters':/[\u0057\u24CC\uFF37\u1E80\u1E82\u0174\u1E86\u1E84\u1E88\u2C72]/g},
+    {'base':'X', 'letters':/[\u0058\u24CD\uFF38\u1E8A\u1E8C]/g},
+    {'base':'Y', 'letters':/[\u0059\u24CE\uFF39\u1EF2\u00DD\u0176\u1EF8\u0232\u1E8E\u0178\u1EF6\u1EF4\u01B3\u024E\u1EFE]/g},
+    {'base':'Z', 'letters':/[\u005A\u24CF\uFF3A\u0179\u1E90\u017B\u017D\u1E92\u1E94\u01B5\u0224\u2C7F\u2C6B\uA762]/g},
+    {'base':'a', 'letters':/[\u0061\u24D0\uFF41\u1E9A\u00E0\u00E1\u00E2\u1EA7\u1EA5\u1EAB\u1EA9\u00E3\u0101\u0103\u1EB1\u1EAF\u1EB5\u1EB3\u0227\u01E1\u00E4\u01DF\u1EA3\u00E5\u01FB\u01CE\u0201\u0203\u1EA1\u1EAD\u1EB7\u1E01\u0105\u2C65\u0250]/g},
+    {'base':'aa','letters':/[\uA733]/g},
+    {'base':'ae','letters':/[\u00E6\u01FD\u01E3]/g},
+    {'base':'ao','letters':/[\uA735]/g},
+    {'base':'au','letters':/[\uA737]/g},
+    {'base':'av','letters':/[\uA739\uA73B]/g},
+    {'base':'ay','letters':/[\uA73D]/g},
+    {'base':'b', 'letters':/[\u0062\u24D1\uFF42\u1E03\u1E05\u1E07\u0180\u0183\u0253]/g},
+    {'base':'c', 'letters':/[\u0063\u24D2\uFF43\u0107\u0109\u010B\u010D\u00E7\u1E09\u0188\u023C\uA73F\u2184]/g},
+    {'base':'d', 'letters':/[\u0064\u24D3\uFF44\u1E0B\u010F\u1E0D\u1E11\u1E13\u1E0F\u0111\u018C\u0256\u0257\uA77A]/g},
+    {'base':'dz','letters':/[\u01F3\u01C6]/g},
+    {'base':'e', 'letters':/[\u0065\u24D4\uFF45\u00E8\u00E9\u00EA\u1EC1\u1EBF\u1EC5\u1EC3\u1EBD\u0113\u1E15\u1E17\u0115\u0117\u00EB\u1EBB\u011B\u0205\u0207\u1EB9\u1EC7\u0229\u1E1D\u0119\u1E19\u1E1B\u0247\u025B\u01DD]/g},
+    {'base':'f', 'letters':/[\u0066\u24D5\uFF46\u1E1F\u0192\uA77C]/g},
+    {'base':'g', 'letters':/[\u0067\u24D6\uFF47\u01F5\u011D\u1E21\u011F\u0121\u01E7\u0123\u01E5\u0260\uA7A1\u1D79\uA77F]/g},
+    {'base':'h', 'letters':/[\u0068\u24D7\uFF48\u0125\u1E23\u1E27\u021F\u1E25\u1E29\u1E2B\u1E96\u0127\u2C68\u2C76\u0265]/g},
+    {'base':'hv','letters':/[\u0195]/g},
+    {'base':'i', 'letters':/[\u0069\u24D8\uFF49\u00EC\u00ED\u00EE\u0129\u012B\u012D\u00EF\u1E2F\u1EC9\u01D0\u0209\u020B\u1ECB\u012F\u1E2D\u0268\u0131]/g},
+    {'base':'j', 'letters':/[\u006A\u24D9\uFF4A\u0135\u01F0\u0249]/g},
+    {'base':'k', 'letters':/[\u006B\u24DA\uFF4B\u1E31\u01E9\u1E33\u0137\u1E35\u0199\u2C6A\uA741\uA743\uA745\uA7A3]/g},
+    {'base':'l', 'letters':/[\u006C\u24DB\uFF4C\u0140\u013A\u013E\u1E37\u1E39\u013C\u1E3D\u1E3B\u017F\u0142\u019A\u026B\u2C61\uA749\uA781\uA747]/g},
+    {'base':'lj','letters':/[\u01C9]/g},
+    {'base':'m', 'letters':/[\u006D\u24DC\uFF4D\u1E3F\u1E41\u1E43\u0271\u026F]/g},
+    {'base':'n', 'letters':/[\u006E\u24DD\uFF4E\u01F9\u0144\u00F1\u1E45\u0148\u1E47\u0146\u1E4B\u1E49\u019E\u0272\u0149\uA791\uA7A5]/g},
+    {'base':'nj','letters':/[\u01CC]/g},
+    {'base':'o', 'letters':/[\u006F\u24DE\uFF4F\u00F2\u00F3\u00F4\u1ED3\u1ED1\u1ED7\u1ED5\u00F5\u1E4D\u022D\u1E4F\u014D\u1E51\u1E53\u014F\u022F\u0231\u00F6\u022B\u1ECF\u0151\u01D2\u020D\u020F\u01A1\u1EDD\u1EDB\u1EE1\u1EDF\u1EE3\u1ECD\u1ED9\u01EB\u01ED\u00F8\u01FF\u0254\uA74B\uA74D\u0275]/g},
+    {'base':'oi','letters':/[\u01A3]/g},
+    {'base':'ou','letters':/[\u0223]/g},
+    {'base':'oo','letters':/[\uA74F]/g},
+    {'base':'p','letters':/[\u0070\u24DF\uFF50\u1E55\u1E57\u01A5\u1D7D\uA751\uA753\uA755]/g},
+    {'base':'q','letters':/[\u0071\u24E0\uFF51\u024B\uA757\uA759]/g},
+    {'base':'r','letters':/[\u0072\u24E1\uFF52\u0155\u1E59\u0159\u0211\u0213\u1E5B\u1E5D\u0157\u1E5F\u024D\u027D\uA75B\uA7A7\uA783]/g},
+    {'base':'s','letters':/[\u0073\u24E2\uFF53\u00DF\u015B\u1E65\u015D\u1E61\u0161\u1E67\u1E63\u1E69\u0219\u015F\u023F\uA7A9\uA785\u1E9B]/g},
+    {'base':'t','letters':/[\u0074\u24E3\uFF54\u1E6B\u1E97\u0165\u1E6D\u021B\u0163\u1E71\u1E6F\u0167\u01AD\u0288\u2C66\uA787]/g},
+    {'base':'tz','letters':/[\uA729]/g},
+    {'base':'u','letters':/[\u0075\u24E4\uFF55\u00F9\u00FA\u00FB\u0169\u1E79\u016B\u1E7B\u016D\u00FC\u01DC\u01D8\u01D6\u01DA\u1EE7\u016F\u0171\u01D4\u0215\u0217\u01B0\u1EEB\u1EE9\u1EEF\u1EED\u1EF1\u1EE5\u1E73\u0173\u1E77\u1E75\u0289]/g},
+    {'base':'v','letters':/[\u0076\u24E5\uFF56\u1E7D\u1E7F\u028B\uA75F\u028C]/g},
+    {'base':'vy','letters':/[\uA761]/g},
+    {'base':'w','letters':/[\u0077\u24E6\uFF57\u1E81\u1E83\u0175\u1E87\u1E85\u1E98\u1E89\u2C73]/g},
+    {'base':'x','letters':/[\u0078\u24E7\uFF58\u1E8B\u1E8D]/g},
+    {'base':'y','letters':/[\u0079\u24E8\uFF59\u1EF3\u00FD\u0177\u1EF9\u0233\u1E8F\u00FF\u1EF7\u1E99\u1EF5\u01B4\u024F\u1EFF]/g},
+    {'base':'z','letters':/[\u007A\u24E9\uFF5A\u017A\u1E91\u017C\u017E\u1E93\u1E95\u01B6\u0225\u0240\u2C6C\uA763]/g}
+  ];
+
+  for(var i=0; i<defaultDiacriticsRemovalMap.length; i++) {
+    str = str.replace(defaultDiacriticsRemovalMap[i].letters, defaultDiacriticsRemovalMap[i].base);
+  }
+
+  return str;
+
+}
+

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -19,7 +19,7 @@ sourceSets {
     }
 }
 
-test {
+def commonConfiguration = {
     systemProperty 'testthreads', System.getProperty('testthreads', '1')
     testLogging {
         events "passed", "skipped", "failed"
@@ -27,6 +27,15 @@ test {
         exceptionFormat = 'full'
     }
     outputs.upToDateWhen { false } // force tests to run everytime
+}
+
+test {
+    configure commonConfiguration
+}
+
+task testWithoutCredentials(type: Test) {
+	exclude 'packages/watson/**'
+	configure commonConfiguration
 }
 
 dependencies {

--- a/tests/src/packages/watson/WatsonTests.scala
+++ b/tests/src/packages/watson/WatsonTests.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package packages.watson
+
+import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.junit.JUnitRunner
+
+import common.JsHelpers
+import common.TestHelpers
+import common.Wsk
+import common.WskProps
+import common.WskTestHelpers
+import common.TestUtils
+import spray.json.DefaultJsonProtocol.StringJsonFormat
+import spray.json.pimpAny
+
+@RunWith(classOf[JUnitRunner])
+class WatsonTests
+    extends TestHelpers
+    with WskTestHelpers
+    with BeforeAndAfterAll
+    with JsHelpers {
+
+    implicit val wskprops = WskProps()
+    val wsk = new Wsk()
+    
+    behavior of "Watson actions"
+
+    it should "identify the language of the text via the Watson Indentify API" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val credentials = TestUtils.getVCAPcredentials("language_translator")
+            val username = credentials.get("username")
+            val password = credentials.get("password")
+            val languageIdAction = "/whisk.system/watson-translator/languageId"
+            val payload = s"Comment allez-vous?".toJson
+            val run = wsk.action.invoke(languageIdAction, Map("username" -> username.toJson, "password" -> password.toJson, "payload" -> payload))
+            withActivation(wsk.activation, run) {
+                activation =>
+                    activation.response.success shouldBe true
+                    activation.response.result.get.fields.get("payload") should be(Some(payload))
+                    activation.response.result.get.fields.get("confidence") == Some(0.785444)
+                    activation.response.result.get.fields.get("language") should be(Some("fr".toJson))
+            }
+    }
+
+    it should "translate the language from one to another via the Watson Translator API" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val credentials = TestUtils.getVCAPcredentials("language_translator")
+            val username = credentials.get("username")
+            val password = credentials.get("password")
+            val translatorAction = "/whisk.system/watson-translator/translator"
+            val text = s"good morning".toJson
+            var result = "bonjour"
+            val run = wsk.action.invoke(translatorAction, Map("username" -> username.toJson, "password" -> password.toJson,
+                "translateFrom" -> "en".toJson, "translateTo" -> "fr".toJson, "translateParam" -> "text".toJson, "text" -> text))
+            withActivation(wsk.activation, run) {
+                activation =>
+                    activation.response.success shouldBe true
+                    activation.response.result.get.fields.get("text").toString.toLowerCase should include(result)
+            }
+    }
+
+    it should "convert the text into speech via the Watson textToSpeech API and convert the speech back to the same text via via the Watson speechToText API" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            var credentials = TestUtils.getVCAPcredentials("text_to_speech")
+            var username = credentials.get("username")
+            var password = credentials.get("password")
+            val textToSpeechAction = "/whisk.system/watson-textToSpeech/textToSpeech"
+            val speech = "hello watson"
+            var results = s""
+            var run = wsk.action.invoke(textToSpeechAction, Map("username" -> username.toJson, "password" -> password.toJson,
+                "payload" -> speech.toJson, "accept" -> "audio/wav".toJson, "encoding" -> "base64".toJson))
+            withActivation(wsk.activation, run) {
+                activation =>
+                    activation.response.success shouldBe true
+                    results = activation.response.result.get.fields.get("payload").get.toString
+            }
+
+            credentials = TestUtils.getVCAPcredentials("speech_to_text")
+            username = credentials.get("username")
+            password = credentials.get("password")
+            val speechToTextAction = "/whisk.system/watson-speechToText/speechToText"
+            run = wsk.action.invoke(speechToTextAction, Map("username" -> username.toJson, "password" -> password.toJson,
+                "payload" -> results.toJson, "content_type" -> "audio/wav".toJson, "encoding" -> "base64".toJson))
+            withActivation(wsk.activation, run) {
+                activation =>
+                    activation.response.success shouldBe true
+                    activation.response.result.get.fields.get("data").toString.toLowerCase should include (speech)
+            }
+    }
+}

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -47,4 +47,4 @@ sed -i 's:^[ \t]*vcap.services.file[ \t]*=\([ \t]*.*\)$:vcap.services.file='$VCA
 # Test
 
 cd $ROOTDIR
-./gradlew :tests:test
+./gradlew :tests:testWithoutCredentials


### PR DESCRIPTION

This patch makes the following changes:
* Split the watson packages into 3 separate packages.
* Add the parameter bluemixServiceName into each watson
package, so that the command "wsk package refresh" is able to
get the latest credential for the service and create the package
binding to the credential.
* Use the new service for Watson language-translator.
* Add the URL as new parameter for the actions under watson-translator.
* Update the documents for watson packages.
* Add the tags to the watson packages.
* Add the test cases for watson packages.