### PR TITLE
Change whisk.invoke into npm openwhisk

### DIFF
--- a/packages/github/webhook.js
+++ b/packages/github/webhook.js
@@ -31,7 +31,7 @@ function main(params) {
   var triggerName = params.triggerName.split("/");
 
     // URL of the whisk system. The calls of github will go here.
-  var whiskCallbackUrl = 'https://' + whisk.getAuthKey() + "@" + params.endpoint + '/api/v1/namespaces/' + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
+  var whiskCallbackUrl = 'https://' + process.env['__OW_API_KEY'] + "@" + params.endpoint + '/api/v1/namespaces/' + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
 
     // The URL to create the webhook on Github
   var registrationEndpoint = 'https://api.github.com/repos/' + (organization ? organization : username) + '/' + repository + '/hooks';
@@ -130,7 +130,7 @@ function main(params) {
 
                   request(options, function(error, response, body) {
                       if (error) {
-                          whisk.error({
+                          reject({
                             response: response,
                             error:error,
                             body:body

--- a/packages/samples/countdown/javascript/countdown.js
+++ b/packages/samples/countdown/javascript/countdown.js
@@ -2,15 +2,18 @@
  * An action that invokes itself recursively, programmatically using the whisk
  * Javascript API.
  */
+var openwhisk = require('openwhisk')
+
 function main(params) {
+    var wsk = openwhisk({ignore_certs: params.ignore_certs || false});
     var n = parseInt(params.n);
     console.log(n);
     if (n === 0) {
         console.log('Happy New Year!');
     } else if (n > 0) {
-        return whisk.invoke({
-            name : 'countdown',
-            parameters : {
+        return wsk.actions.invoke({
+            actionName: process.env['__OW_ACTION_NAME'],
+            params : {
                 n : n - 1
             }
         });

--- a/packages/samples/helloAsync/javascript/helloAsync.js
+++ b/packages/samples/helloAsync/javascript/helloAsync.js
@@ -2,18 +2,18 @@
  * word count utility, coded as an asynchronous action for pedagogical
  * purposes
  */
-function wc(params) {
+function wc(params, resolve) {
     var str = params.payload;
     var words = str.split(" ");
     var count = words.length;
     console.log("The message '"+str+"' has", count, 'words');
-    whisk.done({count: count});
+    resolve({count: count});
 }
 
 function main(params) {
-    setTimeout(function() {
-        wc(params);
-    }, 100);
-
-    return whisk.async();
+    return new Promise(function(resolve, reject) {
+        setTimeout(function() {
+            wc(params, resolve);
+        }, 100);
+    })
 }

--- a/packages/samples/helloPromises/javascript/helloPromises.js
+++ b/packages/samples/helloPromises/javascript/helloPromises.js
@@ -5,17 +5,20 @@
  * @param name A person's name.
  * @param place Where the person is from.
  */
+var openwhisk = require('openwhisk')
+
 function main(params) {
-    return whisk.invoke({
-        name: '/whisk.system/samples/greeting',
-        parameters: {
+    var wsk = openwhisk({ignore_certs: params.ignore_certs || false});
+    return wsk.actions.invoke({
+        actionName: '/whisk.system/samples/greeting',
+        params: {
             name: params.name,
             place: params.place
         },
         blocking: true
-    }).then(function (activation) {
+    }).then(activation => {
         console.log('activation:', activation);
-        var payload = activation.result.payload.toString();
+        var payload = activation.response.result.payload.toString();
         var lines = payload.split(' ');
         return { lines: lines };
     });

--- a/packages/samples/wordcountBinary/javascript/wordcountBinary.js
+++ b/packages/samples/wordcountBinary/javascript/wordcountBinary.js
@@ -2,19 +2,22 @@
  * Return word count as a binary number. This demonstrates the use of a blocking
  * invoke.
  */
+var openwhisk = require('openwhisk')
+
 function main(params) {
+    var wsk = openwhisk({ignore_certs: params.ignore_certs || false});
     var str = params.payload;
     console.log("The payload is '" + str + "'");
 
-    return whisk.invoke({
-        name: '/whisk.system/samples/wordCount',
-        parameters: {
+    return wsk.actions.invoke({
+        actionName: '/whisk.system/samples/wordCount',
+        params: {
             payload: str
         },
         blocking: true
-    }).then(function (activation) {
+    }).then(activation => {
         console.log('activation:', activation);
-        var wordsInDecimal = activation.result.count;
+        var wordsInDecimal = activation.response.result.count;
         var wordsInBinary = wordsInDecimal.toString(2) + ' (base 2)';
         return { binaryCount: wordsInBinary };
     });

--- a/packages/slack/post.js
+++ b/packages/slack/post.js
@@ -12,51 +12,50 @@ var request = require('request');
  *  @return {object} whisk async
  */
 function main(params) {
-
-  if (checkParams(params)) {
-
-    var body = {
-      channel: params.channel,
-      username: params.username || 'Simple Message Bot',
-      text: params.text
-    };
-
-    if (params.icon_emoji) {
-      // guard against sending icon_emoji: undefined
-      body.icon_emoji = params.icon_emoji;
-    }
-
-    if (params.token) {
-      //
-      // this allows us to support /api/chat.postMessage
-      // e.g. users can pass params.url = https://slack.com/api/chat.postMessage
-      //                 and params.token = <their auth token>
-      //
-      body.token = params.token;
-    } else {
-      //
-      // the webhook api expects a nested payload
-      //
-      // notice that we need to stringify; this is due to limitations
-      // of the formData npm: it does not handle nested objects
-      //
-      console.log(body);
-      console.log("to: " + params.url);
-
-      body = {
-        payload: JSON.stringify(body)
-      };
-    }
-
-    if (params.as_user === true) {
-        body.as_user = true;
-    }
-
-    if (params.attachments) {
-      body.attachments = params.attachments;
-    }
-
     var promise = new Promise(function (resolve, reject) {
+      checkParams(params, reject);
+
+      var body = {
+        channel: params.channel,
+        username: params.username || 'Simple Message Bot',
+        text: params.text
+      };
+
+      if (params.icon_emoji) {
+        // guard against sending icon_emoji: undefined
+        body.icon_emoji = params.icon_emoji;
+      }
+
+      if (params.token) {
+        //
+        // this allows us to support /api/chat.postMessage
+        // e.g. users can pass params.url = https://slack.com/api/chat.postMessage
+        //                 and params.token = <their auth token>
+        //
+        body.token = params.token;
+      } else {
+        //
+        // the webhook api expects a nested payload
+        //
+        // notice that we need to stringify; this is due to limitations
+        // of the formData npm: it does not handle nested objects
+        //
+        console.log(body);
+        console.log("to: " + params.url);
+
+        body = {
+          payload: JSON.stringify(body)
+        };
+      }
+
+      if (params.as_user === true) {
+          body.as_user = true;
+      }
+
+      if (params.attachments) {
+          body.attachments = params.attachments;
+      }
+
       request.post({
         url: params.url,
         formData: body
@@ -72,24 +71,19 @@ function main(params) {
     });
 
     return promise;
-  }
 }
 
 /**
 Checks if all required params are set
 */
-function checkParams(params) {
+function checkParams(params, reject) {
   if (params.text === undefined) {
-    whisk.error('No text provided');
-    return false;
+    reject('No text provided');
   }
   if (params.url === undefined) {
-    whisk.error('No Webhook URL provided');
-    return false;
+	reject('No Webhook URL provided');
   }
   if (params.channel === undefined) {
-    whisk.error('No channel provided');
-    return false;
+	reject('No channel provided');
   }
-  return true;
 }

--- a/packages/websocket/sendWebSocketMessageAction.js
+++ b/packages/websocket/sendWebSocketMessageAction.js
@@ -6,28 +6,28 @@
  * @return  Standard OpenWhisk success/error response
  */
 function main(params) {
-    if (!params.uri) {
-        return whisk.error('You must specify a uri parameter.');
-    }
-    var uri = params.uri;
-
-    console.log("URI param is " + params.uri);
-
-    if (!params.payload) {
-        return whisk.error('You must specify a payload parameter.');
-    }
-    var payload = params.payload;
-
-    console.log("Payload param is " + params.payload);
-
-    var WebSocket = require('ws');
-
-    var connectionEstablished = false;
-    var ws = new WebSocket(uri);
-
-    var connectionTimeout = 30 * 1000; // 30 seconds
-
     var promise = new Promise(function(resolve, reject) {
+    	if (!params.uri) {
+            reject('You must specify a uri parameter.');
+        }
+        var uri = params.uri;
+
+        console.log("URI param is " + params.uri);
+
+        if (!params.payload) {
+            reject('You must specify a payload parameter.');
+        }
+        var payload = params.payload;
+
+        console.log("Payload param is " + params.payload);
+
+        var WebSocket = require('ws');
+
+        var connectionEstablished = false;
+        var ws = new WebSocket(uri);
+
+        var connectionTimeout = 30 * 1000; // 30 seconds
+
         setTimeout(function () {
             if (!connectionEstablished) {
                 reject('Did not establish websocket connection to ' + uri + ' in a timely manner.');


### PR DESCRIPTION
Whisk functions will sunset soon. This patch changes the existing deprecated functions into using npm openwhisk.